### PR TITLE
Re-raise HistoryDialog when called twice

### DIFF
--- a/addon/globalPlugins/speechHistoryExplorer.py
+++ b/addon/globalPlugins/speechHistoryExplorer.py
@@ -88,7 +88,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	)
 	def script_showHistorial(self, gesture):
 		gui.mainFrame.prePopup()
-		HistoryDialog(gui.mainFrame, self).Show()
+		d = HistoryDialog(gui.mainFrame, self)
+		d.Show()
+		d.Raise()
 		gui.mainFrame.postPopup()
 
 	def terminate(self, *args, **kwargs):
@@ -163,6 +165,7 @@ class HistoryDialog(
 
 	def __init__(self, parent, addon):
 		if HistoryDialog._instance() is not None:
+			self.updateHistory()
 			return
 		HistoryDialog._instance = weakref.ref(self)
 		# Translators: The title of the history elements Dialog


### PR DESCRIPTION
### Steps to reproduce the issue
1. Press NVDA+alt+F12
2. Alt+tab to another window
3. Do some stuff
4. Press NVDA+alt+F12

### Actual result
At step 1., the dialog is shown.
At step 4., the dialog is not shown again.


### Expected result
At steps 1. and 4., the dialog is shown.
At step 4., the history must also be updated.

### Solution
* The dialog should be put in foreground again (Raise)
* In the `__init__` mehtod, if the dialog already exists, `updateHistory` should be called before returning.

