### PR TITLE
Restore compatibiity with NVDA 2019.3

### DIFF
--- a/addon/globalPlugins/speechHistoryExplorer/__init__.py
+++ b/addon/globalPlugins/speechHistoryExplorer/__init__.py
@@ -8,7 +8,11 @@
 
 import addonHandler, api, globalPluginHandler, gui, speech, speechViewer, tones, versionInfo, weakref, wx
 from collections import deque
-from eventHandler import FocusLossCancellableSpeechCommand
+try:
+	from eventHandler import FocusLossCancellableSpeechCommand
+except ImportError:
+	# For older versions where this class does not exist
+	pass
 from gui import guiHelper, nvdaControls
 from gui.dpiScalingHelper import DpiScalingHelperMixin, DpiScalingHelperMixinWithoutInit
 from queueHandler import eventQueue, queueFunction
@@ -128,7 +132,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(speechHistoryExplorerSettingsPanel)
 
 	def append_to_history(self, seq):
-		seq = [command for command in seq if not isinstance(command, FocusLossCancellableSpeechCommand)]
+		try:
+			seq = [command for command in seq if not isinstance(command, FocusLossCancellableSpeechCommand)]
+		except NameError:  # if FocusLossCancellableSpeechCommand does not exist
+			pass
 		self._history.appendleft(seq)
 		self.history_pos = 0
 
@@ -179,7 +186,6 @@ class speechHistoryExplorerSettingsPanel(gui.SettingsPanel):
 
 class HistoryDialog(
 		DpiScalingHelperMixinWithoutInit,
-		gui.contextHelp.ContextHelpMixin,
 		wx.Dialog  # wxPython does not seem to call base class initializer, put last in MRO
 ):
 	@classmethod


### PR DESCRIPTION
Hi David

Speech History Explorer advertises to be compatible with NVDA 2019.3 but it is not true. This PR restores the compatibility with NVDA 2019.3.

### Issue 1
`FocusLossCancellableSpeechCommand` not yet in 2019.3
#### Fix
Import it and use it only if it exists.

### Issue 2
`gui.contextHelp.ContextHelpMixin` not yet in 2019.3
#### Fix
Removed it since you do this class is for NVDA dialogs; context help for add-ons is not supported by NVDA's context help mechanism.
