### PR TITLE
Do not use deprecated import from gui

### DIFF
--- a/addon/globalPlugins/speechHistoryExplorer/__init__.py
+++ b/addon/globalPlugins/speechHistoryExplorer/__init__.py
@@ -148,7 +148,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.history_pos = 0
 
 
-class speechHistoryExplorerSettingsPanel(gui.SettingsPanel):
+class speechHistoryExplorerSettingsPanel(gui.settingsDialogs.SettingsPanel):
 	# Translators: the label/title for the Speech History Explorer settings panel.
 	title = _('Speech History Explorer')
 


### PR DESCRIPTION
### Issue
Warning in the log due to deprecated import:

```
WARNING - gui.__getattr__ (10:08:12.592) - MainThread (2160):
Importing SettingsPanel from here is deprecated. Import SettingsPanel from gui.settingsDialogs instead. 
Stack trace:
  File "nvda.pyw", line 399, in <module>
  File "core.pyc", line 693, in main
  File "globalPluginHandler.pyc", line 30, in initialize
  File "globalPluginHandler.pyc", line 23, in listPlugins
  File "importlib\__init__.pyc", line 127, in import_module
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\speechHistoryExplorer\globalPlugins\speechHistoryExplorer\__init__.py", line 151, in <module>
    class speechHistoryExplorerSettingsPanel(gui.SettingsPanel):
  File "gui\__init__.pyc", line 115, in __getattr__

```
### Solution
Do not import directly from gui anymore.
